### PR TITLE
Reapplying core hacks

### DIFF
--- a/LdapAuthenticationPlugin.php
+++ b/LdapAuthenticationPlugin.php
@@ -1238,6 +1238,7 @@ class LdapAuthenticationPlugin extends AuthPlugin {
 			$this->printDebug( "Username is: $username", NONSENSITIVE );
 			if ( $this->getConf( 'LowerCaseUsername' ) ) {
 				$canonicalname = ucfirst( strtolower( $canonicalname ) );
+				$canonicalname = str_replace( '_', ' ', $canonicalname ); //Underscore is invalid char in user name
 			} else {
 				# Fetch username, so that we can possibly use it.
 				$userInfo = $wgMemc->get( $key );


### PR DESCRIPTION
This change was made due to ERM6276.

It incorporates changes from different sources

a) Changes to LdapAuthenticationPlugin.php made to avoid an "Invalid token"
issue in API calls (authored by RV)

b) Changed to LdapAutoAuthentication.php made to fix AutoAuth behaviour
in REL1_27 setups (authored by BH)

This might also be merged into master if possible. As we plan to switch to
another plugin in the next release it is not a requirement.